### PR TITLE
wallet: add refresh argument to open_wallet.

### DIFF
--- a/src/wallet/wallet_rpc_server.cpp
+++ b/src/wallet/wallet_rpc_server.cpp
@@ -60,7 +60,7 @@ using namespace epee;
 #define MONERO_DEFAULT_LOG_CATEGORY "wallet.rpc"
 
 #define DEFAULT_AUTO_REFRESH_PERIOD 20 // seconds
-#define REFRESH_INFICATIVE_BLOCK_CHUNK_SIZE 256    // just to split refresh in separate calls to play nicer with other threads
+#define REFRESH_INDICATIVE_BLOCK_CHUNK_SIZE 256    // just to split refresh in separate calls to play nicer with other threads
 
 #define CHECK_MULTISIG_ENABLED() \
   do \
@@ -176,7 +176,7 @@ namespace tools
   }
 
   //------------------------------------------------------------------------------------------------------------------------------
-  wallet_rpc_server::wallet_rpc_server():m_wallet(NULL), rpc_login_file(), m_stop(false), m_restricted(false), m_vm(NULL)
+  wallet_rpc_server::wallet_rpc_server(bool no_initial_sync) : m_wallet(NULL), rpc_login_file(), m_stop(false), m_restricted(false), m_vm(NULL), m_no_initial_sync(no_initial_sync)
   {
   }
   //------------------------------------------------------------------------------------------------------------------------------
@@ -202,13 +202,13 @@ namespace tools
       uint64_t blocks_fetched = 0;
       try {
         bool received_money = false;
-        if (m_wallet) m_wallet->refresh(m_wallet->is_trusted_daemon(), 0, blocks_fetched, received_money, true, true, REFRESH_INFICATIVE_BLOCK_CHUNK_SIZE);
+        if (m_wallet) m_wallet->refresh(m_wallet->is_trusted_daemon(), 0, blocks_fetched, received_money, true, true, REFRESH_INDICATIVE_BLOCK_CHUNK_SIZE);
       } catch (const std::exception& ex) {
         LOG_ERROR("Exception at while refreshing, what=" << ex.what());
       }
       // if we got the max amount of blocks, do not set the last refresh time, we did only part of the refresh and will
       // continue asap, and only set the last refresh time once the refresh is actually finished
-      if (blocks_fetched < REFRESH_INFICATIVE_BLOCK_CHUNK_SIZE)
+      if (blocks_fetched < REFRESH_INDICATIVE_BLOCK_CHUNK_SIZE)
         m_last_auto_refresh_time = boost::posix_time::microsec_clock::universal_time();
       return true;
     }, 1000);
@@ -3628,7 +3628,15 @@ namespace tools
       er.message = "Failed to open wallet";
       return false;
     }
-
+    try
+    {
+      if (!get_no_initial_sync() && req.refresh)
+        wal->refresh(wal->is_trusted_daemon());
+    }
+    catch (const std::exception& e)
+    {
+      LOG_ERROR(tools::wallet_rpc_server::tr("Initial refresh failed: ") << e.what());
+    }
     if (m_wallet)
       delete m_wallet;
     m_wallet = wal.release();
@@ -4805,7 +4813,7 @@ public:
       const auto password_file = command_line::get_arg(vm, arg_password_file);
       const auto prompt_for_password = command_line::get_arg(vm, arg_prompt_for_password);
       const auto password_prompt = prompt_for_password ? password_prompter : nullptr;
-      const auto no_initial_sync = command_line::get_arg(vm, arg_no_initial_sync);
+      wrpc->set_no_initial_sync(command_line::get_arg(vm, arg_no_initial_sync));
 
       if(!wallet_file.empty() && !from_json.empty())
       {
@@ -4863,7 +4871,7 @@ public:
 
       try
       {
-        if (!no_initial_sync)
+        if (!wrpc->get_no_initial_sync())
           wal->refresh(wal->is_trusted_daemon());
       }
       catch (const std::exception& e)

--- a/src/wallet/wallet_rpc_server.h
+++ b/src/wallet/wallet_rpc_server.h
@@ -53,13 +53,21 @@ namespace tools
 
     static const char* tr(const char* str);
 
-    wallet_rpc_server();
+    wallet_rpc_server(bool no_initial_sync = false);
     ~wallet_rpc_server();
 
     bool init(const boost::program_options::variables_map *vm);
     bool run();
     void stop();
     void set_wallet(wallet2 *cr);
+
+    void set_no_initial_sync(bool no_initial_sync){ 
+      this->m_no_initial_sync = no_initial_sync;
+    }
+
+    bool get_no_initial_sync() {
+      return m_no_initial_sync;
+    }
 
   private:
 
@@ -284,6 +292,7 @@ namespace tools
       tools::private_file rpc_login_file;
       std::atomic<bool> m_stop;
       bool m_restricted;
+      bool m_no_initial_sync; 
       const boost::program_options::variables_map *m_vm;
       uint32_t m_auto_refresh_period;
       boost::posix_time::ptime m_last_auto_refresh_time;

--- a/src/wallet/wallet_rpc_server_commands_defs.h
+++ b/src/wallet/wallet_rpc_server_commands_defs.h
@@ -2172,11 +2172,13 @@ namespace wallet_rpc
       std::string filename;
       std::string password;
       bool autosave_current;
+      bool refresh;
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(filename)
         KV_SERIALIZE(password)
         KV_SERIALIZE_OPT(autosave_current, true)
+        KV_SERIALIZE_OPT(refresh, true)
       END_KV_SERIALIZE_MAP()
     };
     typedef epee::misc_utils::struct_init<request_t> request;


### PR DESCRIPTION
	* Clean --no-initial-sync implementation.
	* Fix spelling error.