### PR TITLE
wallet: shortchain history should include base block

### DIFF
--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -3013,6 +3013,8 @@ void wallet2::get_short_chain_history(std::list<crypto::hash>& ids, uint64_t gra
   size_t sz = blockchain_size - m_blockchain.offset();
   if(!sz)
   {
+    if(m_blockchain.size() > m_blockchain.offset())
+      ids.push_back(m_blockchain[m_blockchain.offset()]);
     ids.push_back(m_blockchain.genesis());
     return;
   }


### PR DESCRIPTION
# Short Summary of the Fix

The original get_short_chain_history method in the wallet2 class contained a bug where the base block (the block at m_blockchain.offset()) was not included in the ids list when sz == 0 (i.e., no blocks exist beyond the offset). This caused an incomplete short chain history in edge cases where the wallet had a minimal or empty blockchain view.

The fixed code ensures the correct behavior by:

1. Adding the base block (m_blockchain[m_blockchain.offset()]) to the ids list if the wallet has valid data at or beyond the offset (m_blockchain.size() > m_blockchain.offset()).
2.  Always including the Genesis block (m_blockchain.genesis()), which is crucial for synchronization.

# Impact of the Fix 

The updated code properly includes the base block when sz == 0, ensuring the short chain history is accurate and complete in all scenarios. This fix resolves potential synchronization issues, particularly for wallets with minimal or partially synced blockchain data. It improves reliability during wallet synchronization and avoids missing critical blocks.